### PR TITLE
chore: add tailwindcss debug screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-query": "^3.38.0",
     "react-spinners": "^0.11.0",
     "sharp": "^0.30.3",
+    "tailwindcss-debug-screens": "^2.2.1",
     "wagmi": "^0.2.21",
     "zustand": "^3.7.2"
   },

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,4 +1,6 @@
 import { Html, Head, Main, NextScript } from 'next/document';
+import classNames from 'classnames';
+import { isDev } from 'utils/constants';
 
 export default function Document() {
   return (
@@ -9,7 +11,12 @@ export default function Document() {
         <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png" />
         <link rel="manifest" href="/favicons/site.webmanifest" />
       </Head>
-      <body className="bg-white text-black dark:bg-[#161818] dark:text-white">
+      <body
+        className={classNames(
+          'bg-white text-black dark:bg-[#161818] dark:text-white',
+          { 'debug-screens': isDev }
+        )}
+      >
         <Main />
         <NextScript />
       </body>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,9 +5,13 @@ module.exports = {
   darkMode: 'class',
   theme: {
     extend: {},
+    debugScreens: {
+      position: ['bottom', 'right'],
+    },
   },
   plugins: [
     require('@tailwindcss/forms'),
+    require('tailwindcss-debug-screens'),
     plugin(({ addVariant }) => {
       addVariant('enter', '&[data-enter]');
       addVariant('leave', '&[data-leave]');

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,6 +1,10 @@
 import { ethers, providers } from 'ethers';
 import { Chain, allChains } from 'wagmi';
 
+// NODE_ENV
+export const isDev = process.env.NODE_ENV === 'development';
+export const isProd = process.env.NODE_ENV === 'production';
+
 // TESTNETS
 export const FACTORY_RINKEBY = '0xde1C04855c2828431ba637675B6929A684f84C7F';
 export const FACTORY_KOVAN = '0xd43bb75cc924e8475dff2604b962f39089e4f842';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6750,6 +6750,11 @@ sync-fetch@0.3.1, sync-fetch@^0.3.1:
     buffer "^5.7.0"
     node-fetch "^2.6.1"
 
+tailwindcss-debug-screens@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tailwindcss-debug-screens/-/tailwindcss-debug-screens-2.2.1.tgz#8dd0854a273daa4f30f4c383370872c6bca337cd"
+  integrity sha512-EMyA0CYBzqcZJHtVDvBfmYzfx3NxuK4qDyVO5wnzcGOrmJsv25D9xPpWefVTORTvhE6pCh90Z1WYnLUKsg3yMw==
+
 tailwindcss@^3.0.24:
   version "3.0.24"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.0.24.tgz#22e31e801a44a78a1d9a81ecc52e13b69d85704d"


### PR DESCRIPTION
The [TailwindCSS Debug Screens](https://github.com/jorenvanhee/tailwindcss-debug-screens) plugin will display the currently active screen in development mode.

![Peek 2022-05-22 17-23](https://user-images.githubusercontent.com/1894191/169714584-c8651369-f4cf-4e9c-92ba-c5f4457ea9fb.gif)
