### PR TITLE
Prevent dialog history table to run on each streamed YTD change

### DIFF
--- a/components/Stream/Table/CustomValues/StreamHistory.tsx
+++ b/components/Stream/Table/CustomValues/StreamHistory.tsx
@@ -14,8 +14,6 @@ interface StreamHistoryProps {
 export const StreamHistory = ({ data, className }: StreamHistoryProps) => {
   const historicalData = data.historicalEvents;
 
-  const [ytdAmount, setYtdAmount] = React.useState<string | null>(null);
-
   const dialog = useDialogState();
 
   const { url: chainExplorer, name: explorerName, id } = useChainExplorer();
@@ -60,32 +58,6 @@ export const StreamHistory = ({ data, className }: StreamHistoryProps) => {
     return eventType;
   };
 
-  const setYTD = React.useCallback(() => {
-    const curYear = new Date().getFullYear();
-    if (data === undefined) {
-      setYtdAmount(null);
-    } else {
-      const year = Number(new Date(`01-01-${curYear}`)) / 1e3;
-      const start = Number(data.createdTimestamp);
-      if (year > start) {
-        const totalAmount =
-          (((Date.now() - year) / 1000) * Number(data.amountPerSec) - Number(data.pausedAmount)) / 1e20;
-        setYtdAmount(intl.formatNumber(totalAmount, { maximumFractionDigits: 5, minimumFractionDigits: 5 }));
-      } else {
-        const totalAmount =
-          (((Date.now() - Number(data.createdTimestamp) * 1000) / 1000) * Number(data.amountPerSec) -
-            Number(data.pausedAmount)) /
-          1e20;
-        setYtdAmount(intl.formatNumber(totalAmount, { maximumFractionDigits: 5, minimumFractionDigits: 5 }));
-      }
-    }
-  }, [data]);
-
-  React.useEffect(() => {
-    const id = setInterval(setYTD, 1);
-    return () => clearInterval(id);
-  }, [setYTD]);
-
   return (
     <>
       <button className={classNames('row-action-links', className)} onClick={dialog.toggle}>
@@ -93,7 +65,7 @@ export const StreamHistory = ({ data, className }: StreamHistoryProps) => {
       </button>
       <FormDialog dialog={dialog} title={t0('streamHistory')} className="v-min h-min dark:text-white">
         <section className="text-[#303030]">
-          <span className="font-exo text-sm slashed-zero tabular-nums dark:text-white">{`Streamed YTD: ${ytdAmount} ${data.tokenSymbol}`}</span>
+          <StreamedYTD data={data} shouldRun={dialog.open} />
           <table className=" w-full border-separate" style={{ borderSpacing: '0 2px' }}>
             <thead>
               <tr>
@@ -133,5 +105,42 @@ export const StreamHistory = ({ data, className }: StreamHistoryProps) => {
         </section>
       </FormDialog>
     </>
+  );
+};
+
+const StreamedYTD: React.FC<{ data: IStream; shouldRun: boolean }> = ({ data, shouldRun }) => {
+  const [ytdAmount, setYtdAmount] = React.useState<string | null>(null);
+  const intl = useIntl();
+  const setYTD = React.useCallback(() => {
+    console.log('this is caleld');
+    const curYear = new Date().getFullYear();
+    if (data === undefined) {
+      setYtdAmount(null);
+    } else {
+      const year = Number(new Date(`01-01-${curYear}`)) / 1e3;
+      const start = Number(data.createdTimestamp);
+      if (year > start) {
+        const totalAmount =
+          (((Date.now() - year) / 1000) * Number(data.amountPerSec) - Number(data.pausedAmount)) / 1e20;
+        setYtdAmount(intl.formatNumber(totalAmount, { maximumFractionDigits: 5, minimumFractionDigits: 5 }));
+      } else {
+        const totalAmount =
+          (((Date.now() - Number(data.createdTimestamp) * 1000) / 1000) * Number(data.amountPerSec) -
+            Number(data.pausedAmount)) /
+          1e20;
+        setYtdAmount(intl.formatNumber(totalAmount, { maximumFractionDigits: 5, minimumFractionDigits: 5 }));
+      }
+    }
+  }, [data]);
+
+  React.useEffect(() => {
+    let id: ReturnType<typeof setInterval> | undefined = undefined;
+    if (shouldRun) id = setInterval(setYTD, 1);
+    else clearInterval(id);
+    return () => clearInterval(id);
+  }, [setYTD, shouldRun]);
+
+  return (
+    <span className="font-exo text-sm slashed-zero tabular-nums dark:text-white">{`Streamed YTD: ${ytdAmount} ${data.tokenSymbol}`}</span>
   );
 };


### PR DESCRIPTION
- Moved logic that renders streamed YTD change to a separate component to prevent dialog history table to be rendered each time the amount changes.
> "dialog history table" is the hidden dialog that can be opened clicking "History" link/button in the streams table

- Disabled streamed YTD change calculation in dialog when dialog is not open

Ideal solution:
Only run (render?) the logic of the dialogs when when "History" link/button is clicked and dialog is visible.