### PR TITLE
[FEAT] add walletconnect RPCs from supported networks

### DIFF
--- a/components/Web3/WalletProvider.tsx
+++ b/components/Web3/WalletProvider.tsx
@@ -31,7 +31,18 @@ const connectors: Array<Connector> = [
     options: {
       qrcode: true,
       rpc: {
+        1: 'https://eth.llamarpc.com',
+        5: 'https://ethereum-goerli.publicnode.com',
+        10: 'https://mainnet.optimism.io',
+        56: 'https://bsc.publicnode.com',
+        82: 'https://rpc.meter.io',
+        100: 'https://rpc.gnosischain.com',
         137: 'https://polygon.llamarpc.com',
+        250: 'https://rpc3.fantom.network',
+        1088: 'https://andromeda.metis.io/?owner=1088',
+        42161: 'https://arbitrum-one.publicnode.com',
+        43113: 'https://avalanche-fuji-c-chain.publicnode.com',
+        43114: 'https://api.avax.network/ext/bc/C/rpc',
       },
     },
   }),


### PR DESCRIPTION
Problem:
WalletConnect is the primary way our users connect to dapps at [Den](https://twitter.com/onchainden). One of our users was having trouble approving tokens on Optimism which led us to realizing that WalletConnect RPCs are missing for most networks on the LlamaPay Interface.

Solution:
This PR adds RPCs for networks mentioned in this document https://docs.llamapay.io/technical-stuff/contracts.

RPCs were sourced from [Chainlist](https://chainlist.org/), with selection of which taking precedence in the following order  if an RPC from that source was available:
- llamarpc.com
- RPC from a Chain's foundation / dev team
- publicnode.com